### PR TITLE
:bug: fix bug in transform when feats with nans are selected

### DIFF
--- a/powershap/powershap.py
+++ b/powershap/powershap.py
@@ -421,7 +421,7 @@ class PowerShap(SelectorMixin, BaseEstimator):
         return self._p_values < self.power_alpha
 
     def transform(self, X):
-        check_is_fitted(self, ["_processed_shaps_df", "_p_values"])
+        check_is_fitted(self, ["_processed_shaps_df", "_p_values", "_explainer"])
         if hasattr(self, "feature_names_in_") and isinstance(X, pd.DataFrame):
             assert np.all(X.columns.values == self.feature_names_in_)
             return pd.DataFrame(
@@ -429,3 +429,6 @@ class PowerShap(SelectorMixin, BaseEstimator):
                 columns=self.feature_names_in_[self._get_support_mask()],
             )
         return super().transform(X)
+
+    def _more_tags(self):
+        return self._explainer._get_more_tags()

--- a/tests/test_catboost_powershap.py
+++ b/tests/test_catboost_powershap.py
@@ -47,6 +47,7 @@ def test_catboost_regr_powershap(dummy_regression):
 
 def test_catboost_handle_nans(dummy_classification):
     X, y = dummy_classification
+    X.iloc[:5] = None
     X["nan_col"] = None
     assert np.any(pd.isna(X))
     n_informative = sum([c.startswith("informative") for c in X.columns])


### PR DESCRIPTION
* refactor the `ShapExplainer._validate_data` method (now uses the `force_all_finite="allow-nan"` kwarg)
* fix nan bug in the `transform` method by using tags (this error only occured for catboost models)
