### PR TITLE
Add shuffle parameter to fit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv/
 catboost_info/
+.idea/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/powershap/powershap.py
+++ b/powershap/powershap.py
@@ -291,7 +291,7 @@ class PowerShap(SelectorMixin, BaseEstimator):
 
         return processed_shaps_df
 
-    def fit(self, X, y, stratify=None, groups=None, **kwargs):
+    def fit(self, X, y, stratify=None, shuffle=True, groups=None, **kwargs):
         """Fit the powershap feature selector.
 
         Parameters
@@ -306,6 +306,8 @@ class PowerShap(SelectorMixin, BaseEstimator):
             None.
             Note: if None, than `y` will be used as `stratify` if the stratify flag of
             the object is True.
+        shuffle: bool, default=True
+            Whether or not to shuffle the data before splitting
         groups: array-like of shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into
             train/test set. By default None.
@@ -349,6 +351,7 @@ class PowerShap(SelectorMixin, BaseEstimator):
             loop_its=loop_its,
             val_size=self.val_size,
             stratify=stratify,
+            shuffle=shuffle,
             groups=groups,
             show_progress=self.show_progress,
             **kwargs,

--- a/powershap/shap_wrappers/shap_explainer.py
+++ b/powershap/shap_wrappers/shap_explainer.py
@@ -68,6 +68,7 @@ class ShapExplainer(ABC):
         stratify: np.array = None,
         shuffle: bool = False,
         groups: np.array = None,
+        train_test_indices: np.array = None,
         random_seed_start: int = 0,
         show_progress: bool = False,
         **kwargs,
@@ -90,6 +91,8 @@ class ShapExplainer(ABC):
         groups: np.array, optional
             The group labels for the samples used while splitting the dataset into
             train/test set. By default None.
+        train_test_indices: np.array, optional, default=None
+            Train test indices as list of tuples
         random_seed_start: int, optional
             The random seed to start the iterations with. By default 0.
         **kwargs: dict
@@ -110,8 +113,12 @@ class ShapExplainer(ABC):
             random_uniform_feature = npRandomState.uniform(-1, 1, len(X))
             X["random_uniform_feature"] = random_uniform_feature
 
+            # Custom train test indices
+            if train_test_indices is not None:
+                train_idx, val_idx = train_test_indices[i]
+
             # Perform train-test split
-            if groups is None:
+            elif groups is None:
                 if stratify is None and not shuffle:
                     train_idx, val_idx = train_test_split(
                         np.arange(len(X)),

--- a/powershap/shap_wrappers/shap_explainer.py
+++ b/powershap/shap_wrappers/shap_explainer.py
@@ -66,6 +66,7 @@ class ShapExplainer(ABC):
         loop_its: int,
         val_size: float,
         stratify: np.array = None,
+        shuffle: bool = False,
         groups: np.array = None,
         random_seed_start: int = 0,
         show_progress: bool = False,
@@ -111,13 +112,21 @@ class ShapExplainer(ABC):
 
             # Perform train-test split
             if groups is None:
-                # stratify may be None or not None
-                train_idx, val_idx = train_test_split(
-                    np.arange(len(X)),
-                    test_size=val_size,
-                    random_state=i,
-                    stratify=stratify,
-                )
+                if stratify is None and not shuffle:
+                    train_idx, val_idx = train_test_split(
+                        np.arange(len(X)),
+                        test_size=val_size,
+                        random_state=i,
+                        shuffle=shuffle,
+                    )
+                else:
+                    # stratify may be None or not None
+                    train_idx, val_idx = train_test_split(
+                        np.arange(len(X)),
+                        test_size=val_size,
+                        random_state=i,
+                        stratify=stratify,
+                    )
             elif stratify is None:
                 # groups may be None or not None
                 from sklearn.model_selection import GroupShuffleSplit


### PR DESCRIPTION
Hi,

Added shuffle parameter to fit:

`selector.fit(X, y, shuffle=False)`

Default is True matching sklearn's train_test_split default. 

Thank you for your merge consideration.