### PR TITLE
:broom: avoid missing package errors

### DIFF
--- a/powershap/__init__.py
+++ b/powershap/__init__.py
@@ -1,6 +1,6 @@
 # The init file for PowerShap
 
 __author__ = "Jarne Verhaeghe, Jeroen Van Der Donckt"
-__version__ = '0.0.7'
+__version__ = '0.0.7.1'
 
 from .powershap import PowerShap

--- a/powershap/shap_wrappers/shap_explainer_factory.py
+++ b/powershap/shap_wrappers/shap_explainer_factory.py
@@ -39,8 +39,11 @@ class ShapExplainerFactory:
 
         """
         for explainer_class in cls._explainer_models:
-            if explainer_class.supports_model(model):
-                return explainer_class(model)
+            try:  # To avoid errors when the library is not installed
+                if explainer_class.supports_model(model):
+                    return explainer_class(model)
+            except:
+                pass
         raise ValueError(
             f"Given model ({model}) is not yet supported by our explainer models"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powershap"
-version = "0.0.7"
+version = "0.0.7.1"
 description = "Feature selection using statistical significance of shap values"
 authors = ["Jarne Verhaeghe, Jeroen Van Der Donckt"]
 readme = "README.md"


### PR DESCRIPTION
This PR avoids errors of optional packages not being installed when applying the factory pattern for fetching the appropriate explainer