### PR TITLE
enable validation set for xgboost's fit

### DIFF
--- a/powershap/shap_wrappers/shap_explainer.py
+++ b/powershap/shap_wrappers/shap_explainer.py
@@ -258,7 +258,7 @@ class XGBoostExplainer(ShapExplainer):
     def _fit_get_shap(self, X_train, Y_train, X_val, Y_val, random_seed, **kwargs) -> np.array:
         # Fit the model
         PowerShap_model = copy(self.model).set_params(random_seed=random_seed)
-        PowerShap_model.fit(X_train, Y_train)  # , eval_set=(X_val, Y_val))
+        PowerShap_model.fit(X_train, Y_train, eval_set=[(X_val, Y_val)])
         # Calculate the shap values
         C_explainer = shap.TreeExplainer(PowerShap_model)
         return C_explainer.shap_values(X_val)


### PR DESCRIPTION
This enables the "early_stopping_rounds" parameter to work with xgboost models.