### PR TITLE
Reduce memory usage by removing data copies

### DIFF
--- a/powershap/shap_wrappers/shap_explainer.py
+++ b/powershap/shap_wrappers/shap_explainer.py
@@ -181,8 +181,9 @@ class ShapExplainer(ABC):
             shaps += [Shap_values]
 
             # Python's reference-counting garbage collection has a hard time
-            # cleaning up after some of the work above in at least some cases,
-            # so running a manual gc.collect() here helps a great deal.
+            # cleaning up after performing some of the work above. Running a
+            # manual garbage collection here keeps memory usage from increasing
+            # on every iteration.
             gc.collect()
 
 
@@ -199,11 +200,12 @@ class ShapExplainer(ABC):
 
 ### CATBOOST
 
+from catboost import CatBoostClassifier, CatBoostRegressor
+
+
 class CatboostExplainer(ShapExplainer):
     @staticmethod
     def supports_model(model) -> bool:
-        from catboost import CatBoostClassifier, CatBoostRegressor
-
         supported_models = [CatBoostRegressor, CatBoostClassifier]
         return isinstance(model, tuple(supported_models))
 

--- a/powershap/shap_wrappers/shap_explainer.py
+++ b/powershap/shap_wrappers/shap_explainer.py
@@ -12,6 +12,8 @@ from numpy.random import RandomState
 from sklearn.model_selection import train_test_split
 from tqdm.auto import tqdm
 
+import gc
+
 
 class ShapExplainer(ABC):
     """Interface class for a (POWERshap explainer class."""
@@ -96,23 +98,21 @@ class ShapExplainer(ABC):
         random_col_name = "random_uniform_feature"
         assert random_col_name not in X.columns
 
-        X = X.copy(deep=True)
-
         shaps = []  # TODO: pre-allocate for efficiency
 
         cv_splitter = None
         if cv_split is not None:
-            # Pas the stratify array as y if stratify is not None
+            # Pass the stratify array as y if stratify is not None
             y_ = stratify if stratify is not None else y
             cv_splitter = cv_split(X, y=y_, groups=groups)
 
         iterations = tqdm(range(loop_its)) if show_progress else range(loop_its)
         for i in iterations:
-            npRandomState = RandomState(i + random_seed_start)
+            random_seed = i + random_seed_start
+            npRandomState = RandomState(random_seed)
 
-            # Add uniform random feature to X
-            random_uniform_feature = npRandomState.uniform(-1, 1, len(X))
-            X["random_uniform_feature"] = random_uniform_feature
+            # Add uniform random feature to X.
+            X[random_col_name] = npRandomState.uniform(-1, 1, len(X))
 
             ### A) Split using the wrapped cross-validation splitter
             if cv_splitter is not None:
@@ -152,19 +152,23 @@ class ShapExplainer(ABC):
                         np.arange(len(X)), test_size=val_size, random_state=i, stratify=stratify
                     )
 
-            X_train = X.iloc[np.sort(train_idx)]
-            X_val = X.iloc[np.sort(val_idx)]
+            X_train = X.iloc[np.sort(train_idx)].to_numpy()
+            X_val = X.iloc[np.sort(val_idx)].to_numpy()
             Y_train = y[np.sort(train_idx)]
             Y_val = y[np.sort(val_idx)]
 
             Shap_values = self._fit_get_shap(
-                X_train=X_train.values,
+                X_train=X_train,
                 Y_train=Y_train,
-                X_val=X_val.values,
+                X_val=X_val,
                 Y_val=Y_val,
-                random_seed=i + random_seed_start,
+                random_seed=random_seed,
                 **kwargs,
             )
+
+            # If our data is large, we don't want to hold two copies in memory
+            # at once, so we manually release them before the next assignment.
+            del X_train, X_val, Y_train, Y_val
 
             Shap_values = np.abs(Shap_values)
 
@@ -172,11 +176,22 @@ class ShapExplainer(ABC):
                 Shap_values = np.max(Shap_values, axis=0)
 
             # TODO: consider to convert to even float16?
-            shaps += [np.mean(Shap_values, axis=0).astype("float32")]
+            Shap_values = np.mean(Shap_values, axis=0).astype("float32")
+
+            shaps += [Shap_values]
+
+            # Python's reference-counting garbage collection has a hard time
+            # cleaning up after some of the work above in at least some cases,
+            # so running a manual gc.collect() here helps a great deal.
+            gc.collect()
+
 
         shaps = np.array(shaps)
 
-        return pd.DataFrame(data=shaps, columns=X_train.columns.values)
+        Xcolumns = X.columns.values
+        X.drop(random_col_name, axis=1, inplace=True)
+
+        return pd.DataFrame(data=shaps, columns=Xcolumns)
 
     def _get_more_tags(self):
         return {}
@@ -184,12 +199,11 @@ class ShapExplainer(ABC):
 
 ### CATBOOST
 
-from catboost import CatBoostClassifier, CatBoostRegressor
-
-
 class CatboostExplainer(ShapExplainer):
     @staticmethod
     def supports_model(model) -> bool:
+        from catboost import CatBoostClassifier, CatBoostRegressor
+
         supported_models = [CatBoostRegressor, CatBoostClassifier]
         return isinstance(model, tuple(supported_models))
 

--- a/powershap/shap_wrappers/shap_explainer.py
+++ b/powershap/shap_wrappers/shap_explainer.py
@@ -96,7 +96,6 @@ class ShapExplainer(ABC):
             The keyword arguments for the fit method.
         """
         random_col_name = "random_uniform_feature"
-        assert random_col_name not in X.columns
 
         shaps = []  # TODO: pre-allocate for efficiency
 
@@ -189,10 +188,7 @@ class ShapExplainer(ABC):
 
         shaps = np.array(shaps)
 
-        Xcolumns = X.columns.values
-        X.drop(random_col_name, axis=1, inplace=True)
-
-        return pd.DataFrame(data=shaps, columns=Xcolumns)
+        return pd.DataFrame(data=shaps, columns=X.columns.values)
 
     def _get_more_tags(self):
         return {}

--- a/tests/test_powershap.py
+++ b/tests/test_powershap.py
@@ -257,7 +257,7 @@ def test_no_mutate_df(dummy_classification):
     n_informative = sum([c.startswith("informative") for c in X.columns])
     assert n_informative > 0, "No informative columns in the dummy data!"
 
-    assert isinstance(X, pd.core.frame.DataFrame)
+    assert isinstance(X, pd.DataFrame)
 
     hash1 = hashlib.sha1(pd.util.hash_pandas_object(X).values).hexdigest()
 

--- a/tests/test_powershap.py
+++ b/tests/test_powershap.py
@@ -8,6 +8,8 @@ from powershap import PowerShap
 
 from .conftest import dummy_classification, dummy_regression
 
+import hashlib
+
 ### DEFAULT MODEL & AUTOMATIC MODE
 
 
@@ -246,3 +248,51 @@ def test_powershap_cv_groupshufflesplit(dummy_classification):
     assert selector.cv is not None
 
     selector.fit(X, y, groups=np.random.randint(0, 3, size=len(X)))
+
+
+def test_no_mutate_df(dummy_classification):
+    """Ensure that powershap fit doesn't mutate an input pandas dataframe.
+    """
+    X, y = dummy_classification
+    n_informative = sum([c.startswith("informative") for c in X.columns])
+    assert n_informative > 0, "No informative columns in the dummy data!"
+
+    assert isinstance(X, pd.core.frame.DataFrame)
+
+    hash1 = hashlib.sha1(pd.util.hash_pandas_object(X).values).hexdigest()
+
+    selector = PowerShap(power_iterations=15, automatic=False)
+    assert selector.model is None
+
+    selector.fit(X, y)
+    assert isinstance(selector.model, CatBoostClassifier)
+    selected_feats = selector.transform(X)
+
+    assert len(selected_feats.columns) >= n_informative
+    assert sum([c.startswith("informative") for c in selected_feats.columns]) == n_informative
+
+    hash2 = hashlib.sha1(pd.util.hash_pandas_object(X).values).hexdigest()
+
+    assert hash1 == hash2
+
+
+def test_no_mutate_numpy(dummy_classification):
+    """Ensure that powershap fit doesn't mutate an input numpy array.
+    """
+    X, y = dummy_classification
+
+    X = X.to_numpy()
+
+    hash1 = hashlib.sha1(pd.util.hash_pandas_object(pd.DataFrame(X)).values).hexdigest()
+
+    selector = PowerShap(power_iterations=15, automatic=False)
+    assert selector.model is None
+
+    selector.fit(X, y)
+    assert isinstance(selector.model, CatBoostClassifier)
+    selected_feats = selector.transform(X)
+    assert selected_feats.shape[1] > 0
+
+    hash2 = hashlib.sha1(pd.util.hash_pandas_object(pd.DataFrame(X)).values).hexdigest()
+
+    assert hash1 == hash2


### PR DESCRIPTION
These modifications make it possible to run PowerShap on much larger datasets without running out of memory. This is especially useful in places such as Kubernetes clusters which may terminate your process if you go over a memory limit.